### PR TITLE
Fix resource TYPOs in variables

### DIFF
--- a/quickstart_101-web-app-linux-java_variables.tf
+++ b/quickstart_101-web-app-linux-java_variables.tf
@@ -12,7 +12,7 @@ variable "environment" {
 
 variable "location" {
   type        = "string"
-  description = "Location to deploy the resoruce group"
+  description = "Location to deploy the resource group"
   default     = "West US 2"
 }
 


### PR DESCRIPTION
This should include all misspellings of 'resoruce'