### PR TITLE
Cosmosdb l100 examples

### DIFF
--- a/quickstart_101-cosmos-db-autoscale_main.tf
+++ b/quickstart_101-cosmos-db-autoscale_main.tf
@@ -1,0 +1,47 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">=3.8.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = var.resource_group_name
+  location = var.location
+}
+
+resource "azurerm_cosmosdb_account" "example" {
+  name                      = var.cosmosdb_account_name
+  location                  = var.cosmosdb_account_location
+  resource_group_name       = azurerm_resource_group.example.name
+  offer_type                = "Standard"
+  kind                      = "GlobalDocumentDB"
+  enable_automatic_failover = false
+  geo_location {
+    location          = var.location
+    failover_priority = 0
+  }
+  consistency_policy {
+    consistency_level       = "BoundedStaleness"
+    max_interval_in_seconds = 300
+    max_staleness_prefix    = 100000
+  }
+  depends_on = [
+    azurerm_resource_group.example
+  ]
+}
+
+resource "azurerm_cosmosdb_sql_database" "example" {
+  name                = var.cosmosdb_sqldb_name
+  resource_group_name = azurerm_resource_group.example.name
+  account_name        = azurerm_cosmosdb_account.example.name
+  autoscale_settings {
+    max_throughput = var.max_throughput
+  }
+}

--- a/quickstart_101-cosmos-db-autoscale_outputs.tf
+++ b/quickstart_101-cosmos-db-autoscale_outputs.tf
@@ -1,0 +1,7 @@
+output "cosmosdb_account_id" {
+  value = azurerm_cosmosdb_account.example.id
+}
+
+output "cosmosdb_sql_database_id" {
+  value = azurerm_cosmosdb_sql_database.example.id
+}

--- a/quickstart_101-cosmos-db-autoscale_variables.tf
+++ b/quickstart_101-cosmos-db-autoscale_variables.tf
@@ -1,0 +1,34 @@
+variable "resource_group_name" {
+  type        = string
+  description = "Resource group name"
+}
+
+variable "location" {
+  type        = string
+  description = "Resource group location"
+}
+
+variable "cosmosdb_account_name" {
+  type        = string
+  description = "Cosmos db account name"
+}
+
+variable "cosmosdb_account_location" {
+  type        = string
+  description = "Cosmos db account location"
+}
+
+variable "cosmosdb_sqldb_name" {
+  type        = string
+  description = "value"
+}
+
+variable "max_throughput" {
+  type        = number
+  description = "Cosmos db database max throughput"
+  validation {
+    condition     = var.max_throughput >= 4000 && var.max_throughput <= 1000000
+    error_message = "Cosmos db autoscale max throughput should be equal to or greater than 4000 and less than or equal to 1000000."
+  }
+}
+


### PR DESCRIPTION
Cosmos db sql level 100 examples 
- CosmosDB SQL API with auto-scale
- CosmosDB SQL API with manual scale
- CosmosDB SQL API with aad-rbac
- CosmosDB SQL API with analytical store 
- CosmosDB SQL API with server-side functionality
- CosmosDB SQL API with free-tier

@grayzu 