### PR TITLE
Fix resource TYPOs in variables

### DIFF
--- a/quickstart_101-web-app-linux-container_variables.tf
+++ b/quickstart_101-web-app-linux-container_variables.tf
@@ -12,7 +12,7 @@ variable "environment" {
 
 variable "location" {
   type        = "string"
-  description = "Location to deploy the resoruce group"
+  description = "Location to deploy the resource group"
   default     = "West US 2"
 }
 

--- a/quickstart_101-web-app-linux-java_variables.tf
+++ b/quickstart_101-web-app-linux-java_variables.tf
@@ -12,7 +12,7 @@ variable "environment" {
 
 variable "location" {
   type        = "string"
-  description = "Location to deploy the resoruce group"
+  description = "Location to deploy the resource group"
   default     = "West US 2"
 }
 

--- a/quickstart_101-web-app-windows-dotnet_variables.tf
+++ b/quickstart_101-web-app-windows-dotnet_variables.tf
@@ -12,7 +12,7 @@ variable "environment" {
 
 variable "location" {
   type        = "string"
-  description = "Location to deploy the resoruce group"
+  description = "Location to deploy the resource group"
   default     = "West US 2"
 }
 

--- a/quickstart_201-web-app-docker-acr_variables.tf
+++ b/quickstart_201-web-app-docker-acr_variables.tf
@@ -12,7 +12,7 @@ variable "environment" {
 
 variable "location" {
   type        = "string"
-  description = "Location to deploy the resoruce group"
+  description = "Location to deploy the resource group"
   default     = "West US 2"
 }
 


### PR DESCRIPTION
This should include all misspellings of 'resoruce'